### PR TITLE
Fix imports

### DIFF
--- a/lldap/resource_group_attribute.go
+++ b/lldap/resource_group_attribute.go
@@ -137,7 +137,7 @@ func resourceGroupAttributeCreate(_ context.Context, d *schema.ResourceData, m a
 
 func resourceGroupAttributeRead(_ context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	lc := m.(*LldapClient)
-	schema, getSchemaErr := lc.GetGroupAttributeSchema(d.Get("name").(string))
+	schema, getSchemaErr := lc.GetGroupAttributeSchema(d.Id())
 	if getSchemaErr != nil {
 		return getSchemaErr
 	}

--- a/lldap/resource_group_attribute_assignment.go
+++ b/lldap/resource_group_attribute_assignment.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -92,8 +93,17 @@ func resourceGroupAttributeAssignmentCreate(ctx context.Context, d *schema.Resou
 }
 
 func resourceGroupAttributeAssignmentRead(_ context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	groupId := d.Get("group_id").(int)
-	attributeId := d.Get("attribute_id").(string)
+	id := d.Id()
+	groupIdString, attributeId, ok := strings.Cut(id, resourceGroupAttributeAssignmentIdSeparator)
+	if !ok {
+		return diag.Errorf("not a valid lldap_group_attribute_assignment id: %s", id)
+	}
+
+	groupId, err := strconv.Atoi(groupIdString)
+	if err != nil {
+		return diag.Errorf("group_id should be an integer: %v", err)
+	}
+
 	lc := m.(*LldapClient)
 	group, getGroupErr := lc.GetGroup(groupId)
 	if getGroupErr != nil {

--- a/lldap/resource_member.go
+++ b/lldap/resource_member.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -88,8 +89,17 @@ func resourceMemberCreate(_ context.Context, d *schema.ResourceData, m any) diag
 }
 
 func resourceMemberRead(_ context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	groupId := d.Get("group_id").(int)
-	userId := d.Get("user_id").(string)
+	id := d.Id()
+	groupIdString, userId, ok := strings.Cut(id, ResourceMemberIdSeparator)
+	if !ok {
+		return diag.Errorf("not a valid lldap_member id: %s", id)
+	}
+
+	groupId, err := strconv.Atoi(groupIdString)
+	if err != nil {
+		return diag.Errorf("group_id should be an integer: %v", err)
+	}
+
 	lc := m.(*LldapClient)
 	group, getGroupErr := lc.GetGroup(groupId)
 	if getGroupErr != nil {

--- a/lldap/resource_user.go
+++ b/lldap/resource_user.go
@@ -195,14 +195,6 @@ func resourceUserRead(_ context.Context, d *schema.ResourceData, m any) diag.Dia
 	if getUserErr != nil {
 		return getUserErr
 	}
-	password := d.Get("password").(string)
-	isValidPassword, bindErr := lc.IsValidPassword(user.Id, password)
-	if bindErr != nil {
-		return bindErr
-	}
-	if isValidPassword {
-		user.Password = password
-	}
 	setRdErr := resourceUserSetResourceData(d, user)
 	if setRdErr != nil {
 		return setRdErr

--- a/lldap/resource_user_attribute.go
+++ b/lldap/resource_user_attribute.go
@@ -155,7 +155,7 @@ func resourceUserAttributeCreate(_ context.Context, d *schema.ResourceData, m an
 
 func resourceUserAttributeRead(_ context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	lc := m.(*LldapClient)
-	schema, getSchemaErr := lc.GetUserAttributeSchema(d.Get("name").(string))
+	schema, getSchemaErr := lc.GetUserAttributeSchema(d.Id())
 	if getSchemaErr != nil {
 		return getSchemaErr
 	}

--- a/lldap/resource_user_attribute_assignment.go
+++ b/lldap/resource_user_attribute_assignment.go
@@ -92,8 +92,12 @@ func resourceUserAttributeAssignmentCreate(ctx context.Context, d *schema.Resour
 }
 
 func resourceUserAttributeAssignmentRead(_ context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	userId := d.Get("user_id").(string)
-	attributeId := d.Get("attribute_id").(string)
+	id := d.Id()
+	userId, attributeId, ok := strings.Cut(id, resourceUserAttributeAssignmentIdSeparator)
+	if !ok {
+		return diag.Errorf("not a valid lldap_user_attribute_assignment id: %s", id)
+	}
+
 	lc := m.(*LldapClient)
 	user, getUserErr := lc.GetUser(userId)
 	if getUserErr != nil {


### PR DESCRIPTION
There are two real changes here:

# Fix `lldap_user` import

Looks like the issue here is that `lldap_user` is validating the
password of a user when it's read. This probably works fine when
actually reading the user from LLDAP. But when attempting to import an
`lldap_user` resource into the Terraform state, it fails.

What's going wrong is that when Terraform attempts to import a resource,
all it has to start with is the `id`. That ought to be enough to import
anything (since the `id` is supposed to uniquely identify the resource
in the actual infrastructure. Unfortunately, because only the `id` is
set, attempting to validate the password means that there's only the
`id` to go off of. When the rest of the logic is evaluated for
validating a password, it fails with a highly cryptic error because
there is no password set:
```
Error: could not bind to ldap server: LDAP Result Code 206 "Empty password not allowed by the client": ldap: empty password not allowed by the client
```

Even if you explicitly set a `password` in the resource you're
attempting to import, you get the same situation (because again,
Terraform doesn't populate those other fields when importing).

We opt to remove the validation from the read-side of things. Validating
still makes sense on the update-side, and the create-side will need the
password in order to create a user. So the other methods should be fine
as they are.

For more information, see
https://github.com/tasansga/terraform-provider-lldap/issues/9#issuecomment-2572121500.

# Use `id` as source of truth for reading resources

As it turns out, most of the resources are using data on the resource
itself to read data for the resource. That mostly works for things when
all you're doing is reading resources from LLDAP. But when you need to
import a resource into the Terraform state, it falls apart because
Terraform only provides the `id` as a value (and not the other
attributes).

We move all the resources over to using the `id`, so they can be
importable. This also should continue to work for reading the resources,
since the previously used attributes were either the same as the `id` on
the LLDAP side, or are derived from the `id`.

For more information, see
https://github.com/tasansga/terraform-provider-lldap/issues/9#issuecomment-2572172966.
